### PR TITLE
fix: all union properties are shown

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "devrev",
-  "version": "0.15.0-rc76"
+  "version": "0.16.27"
 }


### PR DESCRIPTION
In this PR, we upgrade the Fern CLI to the latest version (0.16.27). As part of this upgrade there are bug fixes that will register common properties in a `oneOf`.