### PR TITLE
chore: nit fix when creating snap-in version

### DIFF
--- a/fern/docs/pages/start.mdx
+++ b/fern/docs/pages/start.mdx
@@ -77,7 +77,7 @@ devrev snap_in_package create-one --slug my-first-snap-in | jq .
 To create a [snap-in version](/snapin-development/references/cli#snap-in-version), run the following command:
 
 ```bash
-devrev snap_in_version create-one --path ./devrev-snaps-typescript-template | jq .
+devrev snap_in_version create-one --path ./devrev-snaps-typescript-template
 ```
 
 Output:


### PR DESCRIPTION
## Summary

Removing `| jq .` when creating snap-in version since it messes up the interactive interface when providing developer connections