### PR TITLE
Configure Google Tag Manager in docs.yml

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -61,3 +61,7 @@ redirects:
   - source: /sdks/plug/install-android
     destination: /sdks/mobile/android
     permanent: true
+
+analytics:
+  gtm:
+    container-id: G-XP1LEFVYQ9

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "devrev",
-  "version": "0.46.20"
+  "version": "0.46.22"
 }


### PR DESCRIPTION
Same thing as https://github.com/devrev/fern-api-docs/pull/133 but setting the `version` properly to make sure CLI handles the new config data.

To use the `gtm` key, need to make sure version >= 0.46.22 where we added support