### PR TITLE
enh: Add MCP documentation 

### DIFF
--- a/fern/docs/pages/airdrop/initial-domain-mapping.mdx
+++ b/fern/docs/pages/airdrop/initial-domain-mapping.mdx
@@ -7,6 +7,19 @@ The initial domain mapping is installed with your snap-in.
 On each snap-in version update, function to upload these mappings to the Airdrop
 system is triggered.
 
+## Approaches
+
+You can create initial domain mappings using two methods:
+
+1. **Chef-cli UI**: Interactive web interface for comprehensive mapping creation
+2. **Model Context Protocol (MCP)**: AI-assisted mapping creation for developers (experimental)
+
+Choose the chef-cli UI for manual control and testing. Use MCP for rapid prototyping with AI assistance.
+
+<Tip>
+For AI-assisted mapping creation, see the [Model Context Protocol integration guide](./mcp).
+</Tip>
+
 ## Chef-cli initial domain mapping setup
 
 ### Prerequisites
@@ -95,7 +108,7 @@ After the blueprint of the test import is completed, the *Install in this org* b
 
 By repeating this process (run a new import, create a different configuration, merge to the initial mappings), you can create an initial mapping that contains multiple options for the user to choose from.
 
-Finally, the Export button allows you to retrieve the `initial_domain_mapping.json`.
+Finally, when all the fields are mapped without deficiencies, the Export button allows you to retrieve the `initial_domain_mapping.json`.
 
 <Tip>
 You can also provide a local metadata file to the command using the `-m` flag, for example: 

--- a/fern/docs/pages/airdrop/mcp.mdx
+++ b/fern/docs/pages/airdrop/mcp.mdx
@@ -1,0 +1,72 @@
+The Model Context Protocol (MCP) is an open protocol that enables large language models to interact with applications through standardized interfaces.
+
+Chef-cli provides MCP integration through the `chef-cli mcp initial-mapping` subcommand. This integration allows AI assistants to programmatically edit and test initial domain mapping files.
+
+## Prerequisites
+
+- Chef-cli installed and configured
+- MCP-compatible client (Cursor, Claude Code, etc.)
+- External domain metadata file
+- Empty or partially populated initial domain mapping file
+
+## Configuration
+
+Create a `.mcp.json` file with the following content:
+
+```json
+{
+    "mcpServers": {
+        "airdrop": {
+            "command": "chef-cli",
+            "args": [
+                "mcp initial-mapping"
+            ]
+        }
+    }
+}
+```
+
+### Cursor setup
+
+1. Provide `.cursor/mcp.json` in your project root.
+2. Using the editor Agent mode point the AI to the initial domain mapping file.
+3. Use the editor to guide the AI to create the initial domain mappings.
+
+### Claude Code setup
+
+1. Provide `.mcp.json` in your project root.
+2. Using the editor point the AI to the initial domain mapping file.
+3. Use the editor to guide the AI to create the initial domain mappings.
+
+## Usage guidelines
+
+To guide the AI tool, provide the following instructions to your AI assistant:
+
+```markdown
+When asked to perform airdrop initial mapping:
+
+- Refer to the `metadata.json` for the external domain metadata.
+- Use `mappings.json` as your initial domain mapping file.
+- Call 'use_mapping' to test out how the initial mapping behaves on the current metadata
+- Use MCP tools to manipulate the initial mapping when adding and removing record type mappings, or unmapping fields or mapping simple fields. For more complex field mappings you may edit the mapping file directly. Refer to the `initial_mappings_schema.yaml` for its proper format.
+    - If doing so, always use 'use_mapping' to verify the mapping file is still valid.
+```
+
+Adjust file paths according to your project structure.
+
+## Available operations
+
+The MCP server provides tools for:
+
+- Testing mappings against metadata
+- Adding and removing record type mappings
+- Field mapping and unmapping operations
+- Validation of mapping file structure
+
+## Limitations
+
+<Warning>
+MCP integration is experimental. Functionality may vary across different AI models and MCP clients.
+</Warning>
+
+Testing shows good results with Cursor 0.47 and Claude Code. The AI can prepare initial mappings with significant autonomy, though developer oversight remains essential.


### PR DESCRIPTION
This documents MCP as an optional way of creating initial domain mappings. 
It also clarifies when the export button is available in the initial domain mappings UI. 

https://app.devrev.ai/devrev/works/ISS-176634