### PR TITLE
Make customization docs public

### DIFF
--- a/fern/apis/beta/generators.yml
+++ b/fern/apis/beta/generators.yml
@@ -1,4 +1,4 @@
-api: 
+api:
   specs:
     - openapi: ./openapi-beta.yaml
 groups:
@@ -7,7 +7,7 @@ groups:
       - sdks
     generators:
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.35.0
+        version: 0.51.7
         output:
           location: npm
           package-name: "@devrev/api"

--- a/fern/apis/public/generators.yml
+++ b/fern/apis/public/generators.yml
@@ -1,3 +1,3 @@
 api: 
-  struct:
+  specs:
     - openapi: ./openapi-public.yaml

--- a/fern/apis/public/generators.yml
+++ b/fern/apis/public/generators.yml
@@ -1,3 +1,3 @@
 api: 
-  specs:
+  struct:
     - openapi: ./openapi-public.yaml

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -83,6 +83,12 @@ redirects:
   - source: /:path*/airdrop/overview
     destination: /:path*/airdrop
     permanent: true   
+  - source: /beta/guides/object-customization
+    destination: /public/guides/object-customization
+    permanent: true
+  - source: /beta/guides/custom-objects
+    destination: /public/guides/custom-objects
+    permanent: true
 
 analytics:
   ga4:

--- a/fern/docs/pages/custom-objects.mdx
+++ b/fern/docs/pages/custom-objects.mdx
@@ -34,6 +34,9 @@ curl --location 'https://api.devrev.ai/schemas.custom.set' \
     "type": "tenant_fragment",
     "description": "Attributes for Campaign",
     "leaf_type": "campaign",
+    "leaf_type_display_name": "Campaign",
+    "is_custom_leaf_type": true,
+    "id_prefix": "CAMP"
     "fields": [
         {
             "name": "name",
@@ -64,9 +67,7 @@ curl --location 'https://api.devrev.ai/schemas.custom.set' \
                 "Students"
             ]
         }
-    ],
-    "is_custom_leaf_type": true,
-    "id_prefix": "CAMP"
+    ]
 }'
 ```
 

--- a/fern/docs/pages/custom-objects.mdx
+++ b/fern/docs/pages/custom-objects.mdx
@@ -23,7 +23,7 @@ Let's say you want to manage marketing campaigns on DevRev. This guide goes thro
 
 All DevRev objects require a schema. First, create a schema for the "Campaign" custom object. Make sure to replace the `<TOKEN>` with your API token.
 
-### Create a schema and a custom object
+### Create custom objects
 
 ```curl
 curl --location 'https://api.devrev.ai/schemas.custom.set' \
@@ -127,7 +127,7 @@ Note that the `id` field in the above response is the system generated unique ID
 
 The sections below provide more details on the available API endpoints for interacting with custom objects.
 
-### Get a custom object
+### Get custom objects
 
 To get a custom object, use the `custom-objects.get` endpoint:
 
@@ -160,7 +160,7 @@ curl --location 'https://api.devrev.ai/custom-objects.list' \
 }'
 ```
 
-### Update a custom object
+### Update custom objects
 
 To update an existing custom object, use the `custom-objects.update` endpoint. The
 following example updates the budget of the previously created campaign custom object:
@@ -178,7 +178,7 @@ curl --location 'https://api.devrev.ai/custom-objects.update' \
 }'
 ```
 
-### Delete a custom object
+### Delete custom objects
 
 To delete a custom object, use the `custom-objects.delete` endpoint.
 The following example deletes the previously created campaign custom object:

--- a/fern/docs/pages/custom-objects.mdx
+++ b/fern/docs/pages/custom-objects.mdx
@@ -12,8 +12,7 @@ and manage object types tailored to your specific business needs.
 2. **Subtype**: A categorization of a leaf type. For example, "promotion" or "advertising" for a "campaign" leaf type.
 3. **Schema fragment**: A schema fragment defines the schema for an object.
 4. **Custom fields**: User-defined fields that store specific data for your custom object.
-5. **Unique key**: A unique identifier for each custom object. This is useful for maintaining idempotency when retrying custom object creation requests.
-6. **ID prefix**: A unique prefix used to generate the display ID for the custom object. If the `id_prefix` is "CAMP", the generated custom object display ID is "C-CAMP-1". The display ID is used to identify the custom object in the UI, similar to the standard DevRev object display IDs like "ISS-001" for issues.
+5. **ID prefix**: A unique prefix used to generate the display ID for the custom object. If the `id_prefix` is "CAMP", the generated custom object display ID is "C-CAMP-1". The display ID is used to identify the custom object in the UI, similar to the standard DevRev object display IDs like "ISS-001" for issues.
 
 For more details on customization concepts, please refer to the
 [Customization](./object-customization) documentation.
@@ -83,7 +82,6 @@ curl --location 'https://api.devrev.ai/custom-objects.create' \
 --header 'Authorization: Bearer <TOKEN>' \
 --data '{
     "leaf_type": "campaign",
-    "unique_key": "CAMP-001",
     "custom_schema_spec": {
         "tenant_fragment": true
     },
@@ -108,7 +106,6 @@ The response of the above API call is the ID of the custom object created.
     "modified_date": "2024-10-01T07:02:58.958Z",
     "display_id": "C-CAMP-1",
     "leaf_type": "campaign",
-    "unique_key": "CAMP-001"
     "stock_schema_fragment": "don:core:dvrv-us-1:stock_sf/1",
     "custom_schema_fragments": [
       "don:core:dvrv-us-1:devo/demo:tenant_fragment/1"
@@ -250,7 +247,33 @@ curl --location 'https://api.devrev.ai/custom-objects.create' \
         "tnt__target_audience": "Professionals",
         "ctype__social_media_platform": "Facebook",
         "ctype__post_id": "1234567890"
+    }
+}'
+```
+
+### Use unique keys for custom objects
+
+A unique identifier for each custom object can be used to maintain idempotency
+when retrying custom object creation requests. No other custom object of the
+same type can have the same unique key.
+
+```curl {10}
+curl --location 'https://api.devrev.ai/custom-objects.create' \
+--header 'Content-Type: application/json' \
+--header 'Accept: application/json' \
+--header 'Authorization: Bearer <TOKEN>' \
+--data '{
+    "leaf_type": "campaign",
+    "custom_schema_spec": {
+        "tenant_fragment": true
     },
-    "unique_key": "CAMP-001"
+    "unique_key": "CAMP-1",
+    "custom_fields": {
+        "tnt__name": "Summer Sale 2023",
+        "tnt__start_date": "2023-06-01",
+        "tnt__end_date": "2023-08-31",
+        "tnt__budget": 10000,
+        "tnt__target_audience": "Professionals"
+    }
 }'
 ```

--- a/fern/docs/pages/custom-objects.mdx
+++ b/fern/docs/pages/custom-objects.mdx
@@ -1,7 +1,3 @@
-<Callout intent="warning">
-This functionality is in Beta. It is not recommended for use in production applications.
-</Callout>
-
 Custom objects allow you to extend DevRev's data model beyond the standard use-cases
 served by the native apps like Build and Support. Custom objects allow you to create
 and manage object types tailored to your specific business needs.

--- a/fern/docs/pages/customization.mdx
+++ b/fern/docs/pages/customization.mdx
@@ -686,7 +686,7 @@ Any attempt to update a _bug_ object to the _completed_ stage without populating
 the _RCA_ field is rejected.
 
 The supported operators are `==`, `!=`, `&&`, `||`. The `expression` is a
-boolean expression that must return a boolean value.
+binary expression that must return a boolean value.
 
 The `effects` array contains the list of effects of the condition. The following effects are supported:
 * `require`: Whether the field must be set for the condition to be met.

--- a/fern/docs/pages/customization.mdx
+++ b/fern/docs/pages/customization.mdx
@@ -685,7 +685,7 @@ curl --location 'https://api.devrev.ai/schemas.custom.set' \
 Any attempt to update a _bug_ object to the _completed_ stage without populating
 the _RCA_ field is rejected.
 
-The supported operators are `==`, `!=`, `>`, `>=`, `<`, `<=`. The `expression` is a
+The supported operators are `==`, `!=`, `&&`, `||`. The `expression` is a
 boolean expression that must return a boolean value.
 
 The `effects` array contains the list of effects of the condition. The following effects are supported:

--- a/fern/docs/pages/customization.mdx
+++ b/fern/docs/pages/customization.mdx
@@ -402,7 +402,7 @@ following POST request payload to `schemas.custom.set` can be used:
     "fields": [
         ...
     ],
-    "deprecated": true,
+    "is_deprecated": true,
 }
 ```
 

--- a/fern/docs/pages/customization.mdx
+++ b/fern/docs/pages/customization.mdx
@@ -47,7 +47,7 @@ _issue_ would have all _issue_ fields plus _bug_-specific fields like _RCA_.
 
 Subtypes are defined using a schema fragment of type `custom_type_fragment`.
 
-## Customize a DevRev object
+## Customize DevRev objects
 <Callout intent="note">
 Your team needs to track software bugs. You want to know:
 - Which environments are affected (development, testing, production)
@@ -226,7 +226,7 @@ The following custom field types are supported -
 The list variants of all the supported custom field types are also supported.
 In the example above, the `impacted_environments` field is a list of enum values.
 
-## Filtering DevRev objects
+## Filter DevRev objects
 
 <Callout intent="note">
 To demonstrate filtering capabilities, consider finding all bugs in the production
@@ -388,7 +388,7 @@ The object now references the latest fragment version (`custom_type_fragment/2`)
 the optional release notes field is absent, the tenant fragment remains attached,
 allowing for future tenant-specific field additions.
 
-## Deprecate a custom schema fragment
+## Deprecate custom schema fragments
 
 Custom schema fragments can be deprecated to avoid creating work items using them. The
 following POST request payload to `schemas.custom.set` can be used:
@@ -419,7 +419,7 @@ curl --location 'https://api.devrev.ai/schemas.custom.list' \
 
 Deprecated fragments aren't listed in the response.
 
-## UI hints
+## Configure UI hints
 
 UI hints allow customizing the UI/UX of custom fields. So far, `ui.display_name` has
 been used to set the display name of a field. Let's look at the other supported UI
@@ -446,7 +446,7 @@ hints:
 `is_filterable` is not a UI hint but a top level field property.
 </Callout>
 
-## Stock field overrides
+## Override stock fields
 
 The fields available in native DevRev objects are called stock fields. For example,
 `priority` is a stock field of _issue_.
@@ -514,7 +514,7 @@ A few observations can be made from the above payload:
 If you want the overrides to be scoped to a subtype, you can add them to the subtype
 instead.
 
-## Stage customization
+## Customize stages
 
 Stages represent the different phases an object can be in during its lifecycle. For
 example, an issue might go through the following lifecycle:
@@ -541,7 +541,7 @@ and _closed_ states in your organization.
 You want to add a new stage _Needs RCA_ to the _bug_ subtype.
 </Callout>
 
-### Add a custom stage
+### Create custom stages
 
 ```curl
 curl --location 'https://api.devrev.ai/stages.custom.create' \
@@ -558,7 +558,7 @@ A stage can be referenced by any object type. For example, both _issue_ and _tic
 object types can use the _in_development_ stage. It's incorrect to say that the stage is
 bound to an _issue_ or _ticket_.
 
-### Stage diagram
+### Create stage diagrams
 
 A stage diagram determines the allowed transitions between stages for a given object.
 For example, _triage_ stage can transition to _backlog_ stage but not vice versa.
@@ -628,7 +628,7 @@ curl --location 'https://api.devrev.ai/stage-diagrams.create' \
 It is important to specify the start stage for the diagram. This is the default stage that gets assigned to the newly created objects.
 </Callout>
 
-### Apply a stage diagram
+### Apply stage diagrams
 
 The stage diagram created above can be referenced in the _bug_ subtype as follows:
 
@@ -649,7 +649,7 @@ curl --location 'https://api.devrev.ai/schemas.custom.set' \
 
 All objects of the _bug_ subtype now adhere to the stage diagram created above.
 
-## Dependent fields
+## Configure dependent fields
 
 <Callout intent="note">
 The developers in your organization tend to forget to add an RCA when resolving the

--- a/fern/versions/beta.yml
+++ b/fern/versions/beta.yml
@@ -14,10 +14,6 @@ navigation:
     title: Changelog
   - section: Guides
     contents:
-      - page: Object customization
-        path: ../docs/pages/customization.mdx
-      - page: Custom objects
-        path: ../docs/pages/custom-objects.mdx
       - page: Account creation
         path: ../docs/pages/create-accounts.mdx
       - page: Agents async API

--- a/fern/versions/public.yml
+++ b/fern/versions/public.yml
@@ -68,6 +68,12 @@ navigation:
       - page: Restricted messages on a timeline
         slug: timeline-entries
         path: ../docs/pages/timeline-entries.mdx
+      - page: Object customization
+        slug: object-customization
+        path: ../docs/pages/object-customization.mdx
+      - page: Custom objects
+        slug: custom-objects
+        path: ../docs/pages/custom-objects.mdx
   - section: SDKs
     slug: sdks
     path: ../docs/pages/sdks/index.mdx

--- a/fern/versions/public.yml
+++ b/fern/versions/public.yml
@@ -70,7 +70,7 @@ navigation:
         path: ../docs/pages/timeline-entries.mdx
       - page: Object customization
         slug: object-customization
-        path: ../docs/pages/object-customization.mdx
+        path: ../docs/pages/customization.mdx
       - page: Custom objects
         slug: custom-objects
         path: ../docs/pages/custom-objects.mdx


### PR DESCRIPTION
- Add `leaf_type_display_name` in custom object schema
- Document that dependent field expressions are binary
- Update supported operations in dependent field expressions
- s/`deprecated`/`is_deprecated` in schema deprecation example
- Document `unique_key`

https://app.devrev.ai/devrev/works/ISS-168821