### PR TITLE
Add sendException method in documentation for Android SDK

### DIFF
--- a/fern/docs/pages/sdks/mobile/android/features.mdx
+++ b/fern/docs/pages/sdks/mobile/android/features.mdx
@@ -951,6 +951,60 @@ You can check if a screen transition is in progress and manually update the stat
   </Tab>
 </Tabs>
 
+### Track handled exceptions
+
+The DevRev SDK allows you to report handled exceptions from catch blocks using the `sendException` function. This ensures that even if the exception is handled in your app, it will still be logged for diagnostics.
+
+<Tabs>
+  <Tab title="Kotlin">
+    ```kotlin
+    DevRev.sendException(
+      exceptionObj: Throwable,
+      exceptionTag: String
+    )
+    ```
+  </Tab>
+  <Tab title="Java">
+    ```java
+    DevRevObservabilityExtKt.sendException(
+      DevRev.INSTANCE,
+      Throwable exceptionObj,
+      String exceptionTag
+    );
+    ```
+  </Tab>
+</Tabs>
+
+For example:
+
+<Tabs>
+  <Tab title="Kotlin">
+    ```kotlin
+    try {
+      // Your code that may produce an exception.
+    } catch (e: Throwable) {
+      DevRev.sendException(
+        exceptionObj = e,
+        exceptionTag = "login-failure"
+      )
+    }
+    ```
+  </Tab>
+  <Tab title="Java">
+    ```java
+    try {
+      // Your code that may throw an exception.
+    } catch (Throwable e) {
+      DevRevObservabilityExtKt.sendException(
+        DevRev.INSTANCE,
+        e,
+        "login-failure"
+      );
+    }
+    ```
+  </Tab>
+</Tabs>
+
 ## Push notifications
 
 You can configure your app to receive push notifications from the DevRev SDK. The SDK is designed to handle push notifications and execute actions based on the notification's content.


### PR DESCRIPTION
## Summary
Added documentation for the sendException method in the Android SDK features page. This method enables developers to report handled exceptions from catch blocks for diagnostics and observability.

## Connected work items
ISS-211789

## Craftsmanship, integrity, and devil’s advocacy
<!-- Mark the appropriate options with an "x" -->
- [ ] New content in an existing subject area
- [ ] Content in new subject area
- [ ] Updated explanations or definitions
- [ ] Updated code samples
